### PR TITLE
Fix API test URLs 

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -2,7 +2,7 @@
 JWT_ACCESS_TOKEN=<YourJWTAccessTokenHere>
 JWT_REFRESH_TOKEN=<YourJWTRefreshTokenHere>
 
-DEFROST_MAPS_URL=http://maps.defrost.ch/{z}/{x}/{y}.png
-TOKEN_REFRESH_URL=http://api.defrost.ch/v1/token/refresh/
+DEFROST_MAPS_URL=https://maps.defrost.ch/{z}/{x}/{y}.png
+TOKEN_REFRESH_URL=https://api.defrost.ch/v1/token/refresh/
 
 MAPBOX_TOKEN=<YourMapboxTokenHere>

--- a/tests/api_tests/defrost_test.js
+++ b/tests/api_tests/defrost_test.js
@@ -10,7 +10,7 @@
 import axios from 'axios'
 
 // URLs used in this example
-let SAMPLE_API_URL = 'http://api.defrost.ch/v1/snow-covers/'
+let SAMPLE_API_URL = 'https://api.defrost.ch/v1/snow-point/45.9766/7.6585/'
 let TOKEN_REFRESH_URL = process.env.TOKEN_REFRESH_URL
 
 

--- a/tests/api_tests/defrost_test.py
+++ b/tests/api_tests/defrost_test.py
@@ -2,8 +2,8 @@
 import requests
 
 # URLs used in this example
-SAMPLE_API_URL = 'http://api.defrost.ch/v1/snow-covers/'
-TOKEN_REFRESH_URL = 'http://api.defrost.ch/v1/token/refresh/'
+SAMPLE_API_URL = 'https://api.defrost.ch/v1/snow-point/45.9766/7.6585/'
+TOKEN_REFRESH_URL = 'https://api.defrost.ch/v1/token/refresh/'
 # your API tokens
 JWT_ACCESS_TOKEN = 'YOUR ACCESS TOKEN GOES HERE'
 JWT_REFRESH_TOKEN = 'YOUR REFRESH TOKEN GOES HERE'

--- a/tests/api_tests/defrost_test.sh
+++ b/tests/api_tests/defrost_test.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # URLs used in this example
-export API_URL="http://api.defrost.ch/v1/snow-covers/"
-export REFRESH_URL="http://api.defrost.ch/v1/token/refresh/"
+export API_URL="https://api.defrost.ch/v1/snow-point/45.9766/7.6585/"
+export REFRESH_URL="https://api.defrost.ch/v1/token/refresh/"
 # your API tokens
 export JWT_ACCESS_TOKEN="YOUR ACCESS TOKEN GOES HERE"
 export JWT_REFRESH_TOKEN="YOUR REFRESH TOKEN GOES HERE"


### PR DESCRIPTION
In production, we use HTTPS and not HTTP
The "snow-covers" endpoint has been removed. We now showcase snow-point endpoint instead.